### PR TITLE
Update README.md to use DI for IpCountryLocatorInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All sys_redirect records that use a t3://page?uid= link are automatically redire
 
 get the ip country for the current request:
 ````php
-class myClass {
+class MyClass {
     // inject the IpCountryLocatorInterface using constructor DI
     public __construct(
         protected readonly IpCountryLocatorInterface $ipCountryLocator

--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ All sys_redirect records that use a t3://page?uid= link are automatically redire
 
 get the ip country for the current request:
 ````php
-$ipCountryOrNull = GeneralUtility::makeInstance(IpCountryLocatorInterface::class)->getIpCountry();
+class myClass {
+    // inject the IpCountryLocatorInterface using constructor DI
+    public __construct(
+        protected readonly IpCountryLocatorInterface $ipCountryLocator
+    ) {
+    }
+    
+    // retrieve the country from the request
+    public function getIpCountry(): ?string {
+        return $this->ipCountryLocator->getIpCountry();
+    }
+}
 ````
 
 get the detected language:

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->cacheClass(FileCacheStorage::class);
     $rectorConfig->cacheDirectory('./var/cache/rector');
 
-    $paths = array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php|html|typoscript)$'")), fn($path): bool => $path && !str_starts_with($path, 'vendor/'));
+    $paths = array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php|html|typoscript)$'")), fn($path): bool => $path && !str_starts_with((string) $path, 'vendor/'));
 
     $rectorConfig->paths($paths);
 

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use PLUS\GrumPHPConfig\RectorSettings;
 use Rector\Config\RectorConfig;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->parallel();
@@ -14,7 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->cacheClass(FileCacheStorage::class);
     $rectorConfig->cacheDirectory('./var/cache/rector');
 
-    $paths = array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php|html|typoscript)$'")), fn($path): bool => $path && !str_starts_with((string) $path, 'vendor/'));
+    $paths = array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php|html|typoscript)$'")), fn($path): bool => $path && !str_starts_with($path, 'vendor/'));
 
     $rectorConfig->paths($paths);
 
@@ -37,6 +38,7 @@ return static function (RectorConfig $rectorConfig): void {
              * rector should not touch these files
              */
             ReadOnlyClassRector::class,
+            NullToStrictStringFuncCallArgRector::class,
         ]
     );
 };


### PR DESCRIPTION
Latest version `1.3.0` introduced a regression with php 8.3 and Typo3 v12.4:
`$ipCountryOrNull = GeneralUtility::makeInstance(IpCountryLocatorInterface::class)->getIpCountry();` no longer works.

Using constructor DI it works again, updated the `README.md` to reflect that.